### PR TITLE
fix: update documentation URLs in issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://github.com/sjnims/cc-plugin-eval/discussions
     about: Ask questions, share ideas, and get help from the community (preferred for questions)
   - name: Claude Code Documentation
-    url: https://docs.anthropic.com/en/docs/build-with-claude/claude-code
+    url: https://code.claude.com/docs
     about: Official Claude Code documentation and guides
   - name: Agent SDK Documentation
-    url: https://github.com/anthropics/claude-agent-sdk-typescript
+    url: https://platform.claude.com/docs/en/agent-sdk/overview
     about: Claude Agent SDK used for plugin execution


### PR DESCRIPTION
## Summary
- Update Claude Code documentation URL to https://code.claude.com/docs
- Update Agent SDK documentation URL to https://platform.claude.com/docs/en/agent-sdk/overview

## Test plan
- [x] Verified URLs are correct
- [x] All linters pass (typecheck, ESLint, Prettier, markdownlint, yamllint, actionlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)