### PR TITLE
fix: remove deprecated --exclude-file flag from lychee workflow

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -4,7 +4,7 @@ name: Check Links
 # Key flags:
 #   --cache: Cache results to speed up subsequent runs
 #   --exclude-link-local: Skip localhost/127.0.0.1 links (not reachable in CI)
-#   --exclude-file: Use .lycheeignore for links that shouldn't be checked
+# .lycheeignore is auto-detected for URL patterns to exclude
 # Creates a GitHub issue on failure for visibility
 
 on:
@@ -48,7 +48,6 @@ jobs:
             --verbose
             --no-progress
             --exclude-link-local
-            --exclude-file .lycheeignore
             '**/*.md'
           fail: true
         env:


### PR DESCRIPTION
## Summary
- Remove deprecated `--exclude-file .lycheeignore` flag from lychee-action workflow
- Update workflow comments to reflect that `.lycheeignore` is now auto-detected

## Problem
Fixes #10
Fixes #11

The lychee link checker workflow was failing with a regex parse error:
```
Error: regex parse error:
    *.local
    ^
error: repetition operator missing expression
```

This was caused by the deprecated `--exclude-file` flag in lychee v0.21.0+, which appears to interpret patterns differently than the auto-detected `.lycheeignore` file.

## Solution
Remove the deprecated `--exclude-file .lycheeignore` argument. Lychee v0.21.0+ automatically detects and uses the `.lycheeignore` file for URL pattern exclusions, correctly interpreting the regex patterns (e.g., `.*\.local` instead of glob-style `*.local`).

### Alternatives Considered
- Updating `.lycheeignore` patterns: Not needed since the file already uses correct regex syntax
- Downgrading lychee version: Would delay addressing the deprecation

## Changes
- `.github/workflows/links.yml`: Remove `--exclude-file .lycheeignore` from args, update comments

## Testing
- [x] actionlint validation passes
- [x] yamllint validation passes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)