### PR TITLE
feat(ci): add Codecov coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,13 +114,22 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
-      - name: Upload coverage
+      - name: Upload coverage artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()
         with:
           name: coverage-report
           path: coverage/
           retention-days: 7
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@0561704f0f02c16a585d4c7555e57fa2e44cf909 # v5.5.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: sjnims/cc-plugin-eval
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+          verbose: true
 
   build:
     name: Build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cc-plugin-eval
 
 [![CI](https://github.com/sjnims/cc-plugin-eval/actions/workflows/ci.yml/badge.svg)](https://github.com/sjnims/cc-plugin-eval/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/sjnims/cc-plugin-eval/graph/badge.svg)](https://codecov.io/gh/sjnims/cc-plugin-eval)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D20.0.0-brightgreen)](https://nodejs.org/)
 


### PR DESCRIPTION
## Description

Add Codecov integration to the CI pipeline for coverage tracking and reporting. This provides historical coverage trends, PR coverage comments, and a coverage badge for the README.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

### Other

- [x] Documentation (`CLAUDE.md`, `README.md`)
- [x] GitHub templates/workflows (`.github/`)

## Motivation and Context

During the repository audit, coverage reporting was identified as a gap. While the repo already enforces coverage thresholds via vitest, adding Codecov provides:

- Historical coverage trends over time
- Automatic PR comments showing coverage diff
- Visual coverage badge in README
- Third-party validation of coverage claims

This aligns with the project's purpose as an evaluation framework - demonstrating quality practices.

## How Has This Been Tested?

**Test Configuration**:
- Node.js version: 20
- OS: macOS

**Test Steps**:

1. Verified `actionlint` passes on modified workflow
2. Verified `markdownlint` passes on README
3. CODECOV_TOKEN secret already configured in repo settings

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### Documentation

- [x] I have verified all links work correctly

### Linting

- [x] I have run `markdownlint "*.md"` on Markdown files
- [x] I have run `actionlint` on workflow files (if modified)

## Additional Notes

- codecov-action pinned to SHA (`0561704f0f02c16a585d4c7555e57fa2e44cf909`) following repo conventions
- `fail_ci_if_error: false` ensures Codecov issues don't break CI
- Dependabot will auto-update the action via existing github-actions ecosystem config

## Reviewer Notes

**Areas that need special attention**:

- Verify the badge URL is correct for this repo
- First CI run will establish baseline coverage on Codecov

**Known limitations or trade-offs**:

- Badge will show "unknown" until first successful upload
- Forked PRs cannot upload coverage (Codecov security feature)

---

## Pre-Merge Checklist (for maintainers)

- [ ] All CI checks pass
- [ ] Test coverage thresholds maintained
- [ ] No security vulnerabilities introduced
- [ ] Labels are appropriate for the change type