### PR TITLE
feat(ci): add Codecov Test Analytics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         uses: codecov/test-results-action@6ba3fdeec616fb91fd6a389b788a2366835a0fa2 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: test-report.junit.xml
+          files: ./coverage/test-report.junit.xml
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: npm ci
 
       - name: Run tests with coverage
-        run: npm run test:coverage
+        run: npm run test:coverage -- --reporter=junit --outputFile.junit=test-report.junit.xml
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 
@@ -130,6 +130,13 @@ jobs:
           files: ./coverage/lcov.info
           fail_ci_if_error: false
           verbose: true
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@6ba3fdeec616fb91fd6a389b788a2366835a0fa2 # v1.2.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: test-report.junit.xml
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: npm ci
 
       - name: Run tests with coverage
-        run: npm run test:coverage -- --reporter=junit --outputFile.junit=test-report.junit.xml
+        run: npm run test:coverage
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -62,10 +62,14 @@ export default defineConfig({
     // =========================================================================
     // Reporter Configuration
     // Verbose output in CI for better debugging, default locally
+    // JUnit reporter in CI for Codecov Test Analytics
     // =========================================================================
-    reporters: process.env.CI ? ["verbose", "html"] : ["default", "html"],
+    reporters: process.env.CI
+      ? ["verbose", "html", "junit"]
+      : ["default", "html"],
     outputFile: {
       html: "./coverage/test-report.html",
+      junit: "./test-report.junit.xml",
     },
 
     // =========================================================================

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -69,7 +69,7 @@ export default defineConfig({
       : ["default", "html"],
     outputFile: {
       html: "./coverage/test-report.html",
-      junit: "./test-report.junit.xml",
+      junit: "./coverage/test-report.junit.xml",
     },
 
     // =========================================================================


### PR DESCRIPTION
## Description

Add Codecov Test Analytics to track test run times, failure rates, and detect flaky tests.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

### Other

- [x] GitHub templates/workflows (`.github/`)

## Motivation and Context

Codecov Test Analytics provides:
- Test duration trends over time
- Failure rate tracking per test
- Flaky test detection (tests that intermittently pass/fail)
- Failed test reports in PR comments

This complements the coverage reporting added in #15.

## How Has This Been Tested?

**Test Configuration**:
- Node.js version: 20
- OS: macOS

**Test Steps**:

1. Verified `actionlint` passes on modified workflow
2. Verified vitest supports `--reporter=junit --outputFile.junit=<file>` options

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

### Linting

- [x] I have run `actionlint` on workflow files (if modified)

## Additional Notes

- test-results-action pinned to SHA following repo conventions
- Uses `if: ${{ !cancelled() }}` to upload results even if tests fail
- JUnit XML generated alongside existing coverage reports

## Reviewer Notes

**Areas that need special attention**:

- Verify the vitest reporter syntax is correct
- First run will establish baseline in Codecov Test Analytics

---

## Pre-Merge Checklist (for maintainers)

- [ ] All CI checks pass
- [ ] Test coverage thresholds maintained
- [ ] No security vulnerabilities introduced
- [ ] Labels are appropriate for the change type