### PR TITLE
fix: migrate from deprecated test-results-action to codecov-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,10 +133,13 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@6ba3fdeec616fb91fd6a389b788a2366835a0fa2 # v1.2.1
+        uses: codecov/codecov-action@0561704f0f02c16a585d4c7555e57fa2e44cf909 # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          slug: sjnims/cc-plugin-eval
           files: ./coverage/test-report.junit.xml
+          report_type: test_results
+          fail_ci_if_error: false
 
   build:
     name: Build


### PR DESCRIPTION
## Summary

Migrates from the deprecated `codecov/test-results-action` to using `codecov/codecov-action` with `report_type: test_results` as recommended by Codecov.

## Motivation

The CI workflow was showing this deprecation warning:

```
This action is being deprecated in favor of 'codecov-action'.
Please update CI accordingly to use 'codecov-action@v5' with
'report_type: test_results'.
The 'codecov-action' should and can be run at least once for
coverage and once for test results
```

## Changes

- Replace `codecov/test-results-action@v1.2.1` with `codecov/codecov-action@v5.5.2`
- Add `report_type: test_results` parameter to distinguish from coverage upload
- Add `slug` and `fail_ci_if_error: false` for consistency with coverage upload step
- Use same SHA-pinned version (`0561704f0f02c16a585d4c7555e57fa2e44cf909`) as existing coverage upload

## Testing

- [x] actionlint passes
- [ ] CI workflow runs successfully
- [ ] Test results upload completes without deprecation warning

## Checklist

- [x] Code follows project conventions
- [x] Changes are focused and minimal
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)