### PR TITLE
test(agent-analyzer): add comprehensive tests for state machine fallback parser

### DIFF
--- a/tests/unit/stages/1-analysis/agent-analyzer.test.ts
+++ b/tests/unit/stages/1-analysis/agent-analyzer.test.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   analyzeAgent,
@@ -87,6 +87,386 @@ response"
   it("returns empty array for no examples", () => {
     const examples = extractAgentExamples("No examples here");
     expect(examples).toHaveLength(0);
+  });
+
+  describe("state machine fallback parser", () => {
+    it("forces state machine fallback when no assistant line present", () => {
+      // This MUST trigger state machine because regex requires \nassistant: lookahead
+      // Without assistant: line, regex pattern fails completely
+      const description = `
+<example>
+Context: User wants help
+user: Just a user message with no assistant response
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.user_message).toBe(
+        "Just a user message with no assistant response",
+      );
+      expect(examples[0]?.expected_response).toBe("");
+      expect(examples[0]?.context).toBe("User wants help");
+    });
+
+    it("forces state machine when assistant has no newline boundary", () => {
+      // Regex requires \n<commentary> or </example> after assistant
+      // By having content between assistant and </example> without proper boundary
+      const description = `
+<example>
+user: Simple message
+assistant: Response</example>
+      `;
+      // Note: </example> is on same line as assistant - regex lookahead fails
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.user_message).toBe("Simple message");
+    });
+
+    it("falls back to state machine when regex cannot match user content", () => {
+      // This format breaks regex because the non-greedy [\s\S]*? can't properly
+      // capture user content when there's no clear boundary before assistant:
+      // The regex needs \nassistant: lookahead, but here content flows differently
+      const description = `
+<example>
+Context: Testing fallback
+user: Hello
+there friend
+assistant: Response here
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.user_message).toContain("Hello");
+      expect(examples[0]?.context).toBe("Testing fallback");
+    });
+
+    it("handles unquoted user and assistant content via state machine", () => {
+      const description = `
+<example>
+user: This message has no quotes
+assistant: Neither does this response
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.user_message).toBe("This message has no quotes");
+      expect(examples[0]?.expected_response).toBe("Neither does this response");
+    });
+
+    it("handles content with embedded colons via state machine", () => {
+      const description = `
+<example>
+Context: User asking about time: format
+user: What time is it: morning or evening?
+assistant: The time: check your clock
+<commentary>Tests colon handling</commentary>
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.user_message).toContain("What time is it");
+    });
+
+    it("parses examples with continuation lines in user message", () => {
+      const description = `
+<example>
+user: First line
+second line continues
+third line too
+assistant: Got all three lines
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      // State machine joins lines with spaces
+      expect(examples[0]?.user_message).toContain("First line");
+      expect(examples[0]?.user_message).toContain("second line");
+      expect(examples[0]?.user_message).toContain("third line");
+    });
+
+    it("parses examples with continuation lines in assistant message", () => {
+      const description = `
+<example>
+user: Simple question
+assistant: First part of response
+continuing the response
+more content here
+<commentary>Multi-line response</commentary>
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.expected_response).toContain("First part");
+      expect(examples[0]?.expected_response).toContain("continuing");
+    });
+
+    it("parses examples with multi-line context", () => {
+      const description = `
+<example>
+Context: This context spans
+multiple lines of text
+with various details
+user: Question here
+assistant: Answer here
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.context).toContain("multiple lines");
+    });
+
+    it("parses examples with multi-line commentary", () => {
+      const description = `
+<example>
+user: Test message
+assistant: Test response
+<commentary>
+This commentary
+spans multiple
+lines
+</commentary>
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.commentary).toContain("spans multiple");
+    });
+
+    it("handles mixed quote styles", () => {
+      const description = `
+<example>
+user: 'Single quoted message'
+assistant: "Double quoted response"
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      // Quotes should be stripped
+      expect(examples[0]?.user_message).not.toContain("'");
+      expect(examples[0]?.expected_response).not.toContain('"');
+    });
+
+    it("handles empty commentary block", () => {
+      const description = `
+<example>
+user: Message here
+assistant: Response here
+<commentary></commentary>
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.commentary).toBe("");
+    });
+
+    it("returns null for example with no user message", () => {
+      const description = `
+<example>
+Context: Just context
+assistant: Just response
+</example>
+      `;
+
+      // Should warn and skip - mock console.warn
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("handles whitespace-only lines between sections", () => {
+      const description = `
+<example>
+user: Message with blank lines
+
+assistant: Response after blank
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.user_message).toBe("Message with blank lines");
+    });
+
+    it("parses commentary tag on separate line via state machine", () => {
+      // Force state machine parsing with unquoted multi-line format
+      // The <commentary> tag on its own line tests state transition
+      const description = `
+<example>
+user: Question that spans
+multiple lines here
+assistant: Answer that also
+spans lines
+<commentary>
+Commentary on its own line
+More commentary
+</commentary>
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.commentary).toContain("Commentary on its own line");
+      expect(examples[0]?.commentary).toContain("More commentary");
+    });
+
+    it("handles closing example tag transition", () => {
+      // Test where </example> triggers state transition back to init
+      const description = `
+<example>
+user: Message
+assistant: Response
+that continues
+on multiple lines
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      // Should capture all assistant content before </example>
+      expect(examples[0]?.expected_response).toContain("continues");
+    });
+  });
+
+  describe("edge cases", () => {
+    it("handles assistant: appearing inside user message", () => {
+      const description = `
+<example>
+user: "The assistant: mentioned something"
+assistant: "I see you mentioned an assistant"
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.user_message).toContain("assistant: mentioned");
+    });
+
+    it("handles user: appearing inside assistant message", () => {
+      const description = `
+<example>
+user: "Regular question"
+assistant: "The user: asked a question"
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.expected_response).toContain("user: asked");
+    });
+
+    it("handles example blocks with extra whitespace", () => {
+      const description = `
+
+<example>
+
+Context:   Lots of spaces   
+user:    Spaced out message    
+assistant:    Spaced response    
+
+</example>
+
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.user_message).toBeTruthy();
+    });
+
+    it("handles case-insensitive section names", () => {
+      const description = `
+<example>
+CONTEXT: Uppercase context
+USER: Uppercase user message
+ASSISTANT: Uppercase response
+<COMMENTARY>Uppercase commentary</COMMENTARY>
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(1);
+      expect(examples[0]?.user_message).toBe("Uppercase user message");
+      expect(examples[0]?.context).toBe("Uppercase context");
+    });
+
+    it("handles malformed example blocks gracefully", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const description = `
+<example>
+This has no proper structure at all
+Just random text
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+
+    it("parses multiple examples with mixed formatting", () => {
+      const description = `
+<example>
+user: "Quoted example"
+assistant: "Quoted response"
+</example>
+
+<example>
+user: Unquoted example
+assistant: Unquoted response
+</example>
+
+<example>
+Context: With context
+user: Third example
+assistant: Third response
+<commentary>Has commentary</commentary>
+</example>
+      `;
+
+      const examples = extractAgentExamples(description);
+
+      expect(examples).toHaveLength(3);
+      expect(examples[0]?.user_message).toBe("Quoted example");
+      expect(examples[1]?.user_message).toBe("Unquoted example");
+      expect(examples[2]?.context).toBe("With context");
+    });
   });
 });
 


### PR DESCRIPTION
## Description

Adds comprehensive tests for the agent analyzer's state machine fallback parser and related functions. This addresses the low test coverage (42.66%) reported in issue #20 by adding 21 new test cases that exercise previously untested code paths.

## Type of Change

- [x] Test (adding or updating tests)

## Component(s) Affected

### Pipeline Stages

- [x] Stage 1: Analysis (`src/stages/1-analysis/`)

### Other

- [x] Tests (`tests/`)

## Motivation and Context

The agent analyzer had incomplete test coverage with critical paths untested:
- `parseExampleWithStateMachine` fallback parser (lines 197-236)
- State transitions array (lines 164-187)
- `extractContent` helper function (lines 148-152)

This PR adds tests that specifically trigger these code paths, improving coverage from 42.66% to 91.66%.

Fixes #20

## How Has This Been Tested?

**Test Configuration**:
- Node.js version: v25.2.1
- OS: macOS 26.x (Darwin 25.2.0)

**Test Steps**:

1. Run `npm test` - All 773 tests pass
2. Run `npm run typecheck` - No type errors
3. Run `npm run lint` - No linting issues
4. Run `npx prettier --check "tests/**/*.ts"` - All files formatted correctly

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### TypeScript / Code Quality

- [x] All functions have explicit return types
- [x] Strict TypeScript checks pass (`npm run typecheck`)
- [x] ESM import/export patterns used correctly
- [x] Unused parameters prefixed with `_`
- [x] No `any` types without justification

### Documentation

- [x] I have updated CLAUDE.md if behavior or commands changed (N/A - tests only)
- [x] I have updated inline JSDoc comments where applicable (N/A - tests only)
- [x] I have verified all links work correctly (N/A)

### Linting

- [x] I have run `npm run lint` and fixed all issues
- [x] I have run `npx prettier --check "src/**/*.ts" "*.json" "*.md"`
- [x] I have run `markdownlint "*.md"` on Markdown files
- [x] I have run `uvx yamllint -c .yamllint.yml` on YAML files (N/A)
- [x] I have run `actionlint` on workflow files (N/A)

### Testing

- [x] I have run `npm test` and all tests pass
- [x] I have added tests for new functionality
- [x] Test coverage meets thresholds (78% lines, 75% functions, 65% branches)
- [x] I have tested with a sample plugin (N/A - test file changes only)

## Stage-Specific Checks

<details>
<summary><strong>Stage 1: Analysis</strong> (click to expand)</summary>

- [x] Plugin parsing handles edge cases (missing fields, malformed YAML)
- [x] Trigger extraction works for all component types (skills, agents, commands)
- [x] Zod validation schemas are correct and complete (N/A)
- [x] Error messages are clear and actionable

</details>

## Example Output (if applicable)

```text
# agent-analyzer.ts coverage before:
...t-analyzer.ts |   42.66 |    31.25 |   20.83 |   43.05 | ...49-151,164-230

# agent-analyzer.ts coverage after:
...t-analyzer.ts |   90.66 |       75 |    87.5 |   91.66 | ...93,180-181,221
```

## Additional Notes

### New Test Cases Added

**State Machine Fallback Parser Tests:**
- Forces state machine fallback when no assistant line present
- Forces state machine when assistant has no newline boundary
- Handles unquoted user and assistant content
- Handles content with embedded colons
- Parses continuation lines in user/assistant messages
- Parses multi-line context and commentary

**Edge Case Tests:**
- Handles `assistant:` appearing inside user message
- Handles `user:` appearing inside assistant message
- Handles extra whitespace in example blocks
- Handles case-insensitive section names
- Handles malformed example blocks gracefully
- Parses multiple examples with mixed formatting

## Reviewer Notes

**Areas that need special attention**:
- The tests that "force" state machine fallback rely on specific formatting that breaks regex patterns but works with the state machine parser

**Known limitations or trade-offs**:
- Some minor branches (lines 93, 180-181, 221) remain uncovered as they represent edge cases that are difficult to trigger without mocking internal functions

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)