### PR TITLE
feat: add symlink resolution to plugin path validation

### DIFF
--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -97,6 +97,7 @@ export interface ResolvedPaths {
 export interface PreflightError {
   code:
     | "PATH_NOT_FOUND"
+    | "PATH_RESOLUTION_FAILED"
     | "MANIFEST_NOT_FOUND"
     | "MANIFEST_PARSE_ERROR"
     | "MANIFEST_INVALID";
@@ -118,6 +119,7 @@ export interface PreflightWarning {
 export interface PreflightResult {
   valid: boolean;
   pluginPath: string;
+  resolvedPath: string;
   manifestPath: string;
   pluginName: string | null;
   errors: PreflightError[];


### PR DESCRIPTION
## Description

Add defense-in-depth security improvement that resolves symlinks during preflight validation. When a plugin path is a symlink, the real path is resolved and used for all subsequent validation checks.

Key changes:
- Detect symlinks using `lstatSync()` and resolve with `realpathSync()`
- Add `SYMLINK_RESOLVED` warning when a symlink is followed
- Add `PATH_RESOLUTION_FAILED` error code for resolution failures
- Add `resolvedPath` field to `PreflightResult` for transparency
- Continue validation using the resolved path for manifest checks

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance optimization (improves efficiency without changing behavior)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Test (adding or updating tests)
- [ ] Documentation update (improvements to README, CLAUDE.md, or inline docs)
- [ ] Configuration change (changes to config.yaml, eslint, tsconfig, etc.)

## Component(s) Affected

### Pipeline Stages

- [x] Stage 1: Analysis (`src/stages/1-analysis/`)
- [ ] Stage 2: Generation (`src/stages/2-generation/`)
- [ ] Stage 3: Execution (`src/stages/3-execution/`)
- [ ] Stage 4: Evaluation (`src/stages/4-evaluation/`)

### Core Infrastructure

- [ ] CLI & Pipeline Orchestration (`src/index.ts`)
- [ ] Configuration (`src/config/`)
- [ ] State Management (`src/state/`)
- [x] Types (`src/types/`)
- [ ] Utilities (`src/utils/`)

### Other

- [x] Tests (`tests/`)
- [ ] Documentation (`CLAUDE.md`, `README.md`)
- [ ] Configuration files (`config.yaml`, `eslint.config.js`, `tsconfig.json`, etc.)
- [ ] GitHub templates/workflows (`.github/`)
- [ ] Other (please specify):

## Motivation and Context

This was identified during a security audit. While no active exploitation vector was found (the framework runs in a trusted environment with user-controlled plugins), this follows defense-in-depth principles:

1. A symlink could point to a location outside the expected plugin directory
2. Symlink race conditions could be exploited during validation
3. The actual plugin loaded might differ from what was validated

Fixes #23

## How Has This Been Tested?

**Test Configuration**:

- Node.js version: v25.2.1
- OS: macOS 26.1 (Darwin 25.2.0)

**Test Steps**:

1. `npm run lint` - ESLint passes
2. `npm run typecheck` - TypeScript strict checks pass
3. `npx prettier --check "src/**/*.ts" "tests/**/*.ts"` - Formatting passes
4. `npm test` - All 786 tests pass, including 5 new symlink tests

New tests added:
- `resolves symlinks and includes resolved path in result`
- `adds warning when symlink is followed`
- `fails for broken symlinks`
- `sets resolvedPath equal to pluginPath for non-symlink paths`
- `no symlink warning for non-symlink paths`

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### TypeScript / Code Quality

- [x] All functions have explicit return types
- [x] Strict TypeScript checks pass (`npm run typecheck`)
- [x] ESM import/export patterns used correctly
- [x] Unused parameters prefixed with `_`
- [x] No `any` types without justification

### Documentation

- [x] I have updated CLAUDE.md if behavior or commands changed (N/A - no behavior change for users)
- [x] I have updated inline JSDoc comments where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `npm run lint` and fixed all issues
- [x] I have run `npx prettier --check "src/**/*.ts" "*.json" "*.md"`
- [x] I have run `markdownlint "*.md"` on Markdown files (N/A - no MD changes)
- [x] I have run `uvx yamllint -c .yamllint.yml` on YAML files (if modified) (N/A)
- [x] I have run `actionlint` on workflow files (if modified) (N/A)

### Testing

- [x] I have run `npm test` and all tests pass
- [x] I have added tests for new functionality
- [x] Test coverage meets thresholds (78% lines, 75% functions, 65% branches)
- [x] I have tested with a sample plugin (if applicable)

## Stage-Specific Checks

<details>
<summary><strong>Stage 1: Analysis</strong> (click to expand)</summary>

- [x] Plugin parsing handles edge cases (missing fields, malformed YAML)
- [x] Trigger extraction works for all component types (skills, agents, commands)
- [x] Zod validation schemas are correct and complete
- [x] Error messages are clear and actionable

</details>

## Reviewer Notes

**Areas that need special attention**:

- The symlink resolution logic at `preflight.ts:50-74`
- Test cleanup in `afterEach` using `fs.rmSync` with `recursive: true`

**Known limitations or trade-offs**:

- We log a warning but don't reject symlinks by default (maintains backwards compatibility)
- No configuration option for symlink policy yet (could be added if needed)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)