### PR TITLE
feat(evaluation): track actual trigger_accuracy consensus in multi-sampling

### DIFF
--- a/src/stages/4-evaluation/metrics.ts
+++ b/src/stages/4-evaluation/metrics.ts
@@ -176,7 +176,7 @@ export function countErrorsByType(
 /**
  * Calculate multi-sampling statistics.
  *
- * @param sampleData - Per-scenario sample data
+ * @param sampleData - Per-scenario sample data including consensus info
  * @returns Multi-sample statistics or undefined if no sampling
  */
 export function calculateMultiSampleStats(
@@ -184,6 +184,8 @@ export function calculateMultiSampleStats(
     scenarioId: string;
     variance: number;
     numSamples: number;
+    /** Whether all samples agreed on trigger_accuracy */
+    hasConsensus: boolean;
   }[],
 ): MultiSampleStats | undefined {
   if (sampleData.length === 0 || sampleData[0]?.numSamples === 1) {
@@ -200,9 +202,9 @@ export function calculateMultiSampleStats(
     .filter((s) => s.variance > highVarianceThreshold)
     .map((s) => s.scenarioId);
 
-  // Consensus rate (scenarios where all samples agreed on trigger_accuracy)
-  // This would need to be calculated during evaluation, using placeholder
-  const consensusRate = 1 - highVarianceScenarios.length / sampleData.length;
+  // Consensus rate: % of scenarios where all samples agreed on trigger_accuracy
+  const consensusCount = sampleData.filter((s) => s.hasConsensus).length;
+  const consensusRate = consensusCount / sampleData.length;
 
   return {
     samples_per_scenario: samplesPerScenario,
@@ -321,6 +323,8 @@ export function calculateEvalMetrics(
       scenarioId: string;
       variance: number;
       numSamples: number;
+      /** Whether all samples agreed on trigger_accuracy */
+      hasConsensus: boolean;
     }[];
     flakyScenarios?: string[];
   } = {},

--- a/src/types/evaluation.ts
+++ b/src/types/evaluation.ts
@@ -79,6 +79,8 @@ export interface MultiSampleResult {
   aggregated_score: number;
   score_variance: number;
   consensus_trigger_accuracy: "correct" | "incorrect" | "partial";
+  /** Whether all samples agreed on trigger_accuracy (unanimous vote) */
+  is_unanimous: boolean;
   all_issues: string[];
   representative_response: JudgeResponse;
 }


### PR DESCRIPTION
## Description

Track actual `trigger_accuracy` consensus in multi-sampling metrics instead of using a variance-based approximation.

Previously, `consensus_rate` assumed that low quality score variance equals consensus on trigger accuracy. This was inaccurate because samples could have similar quality scores but disagree on trigger_accuracy, or have different scores but unanimously agree.

This PR adds proper tracking of trigger_accuracy unanimity across samples.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

### Pipeline Stages

- [x] Stage 4: Evaluation (`src/stages/4-evaluation/`)

### Core Infrastructure

- [x] Types (`src/types/`)

### Other

- [x] Tests (`tests/`)

## Motivation and Context

The `consensus_rate` metric in `calculateMultiSampleStats` used this approximation:

```typescript
const consensusRate = 1 - highVarianceScenarios.length / sampleData.length;
```

This assumed low score variance equals agreement, but:
- Samples with scores [8, 8, 8] could disagree: `["correct", "incorrect", "partial"]`
- Samples with scores [3, 8, 10] could all agree: `["correct", "correct", "correct"]`

This enhancement was identified during PR #30 review.

Fixes #31

## How Has This Been Tested?

**Test Configuration**:
- Node.js version: 25.2.1
- OS: macOS 26.1

**Test Steps**:

1. Run `npm run lint` - all linting passes
2. Run `npm run typecheck` - all type checks pass
3. Run `npm test` - all 237 tests pass
4. Run `npx prettier --check` on modified files - formatting correct

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### TypeScript / Code Quality

- [x] All functions have explicit return types
- [x] Strict TypeScript checks pass (`npm run typecheck`)
- [x] ESM import/export patterns used correctly
- [x] Unused parameters prefixed with `_`
- [x] No `any` types without justification

### Documentation

- [x] I have updated inline JSDoc comments where applicable

### Linting

- [x] I have run `npm run lint` and fixed all issues
- [x] I have run `npx prettier --check "src/**/*.ts" "*.json" "*.md"`

### Testing

- [x] I have run `npm test` and all tests pass
- [x] I have added tests for new functionality
- [x] Test coverage meets thresholds (90.96% lines, 90.16% functions, 80.14% branches)

## Stage-Specific Checks

<details>
<summary><strong>Stage 4: Evaluation</strong> (click to expand)</summary>

- [x] Programmatic detection correctly parses Skill/Task/SlashCommand tool calls
- [x] Result aggregation methods work correctly
- [x] Multi-sampling correctly tracks is_unanimous field

</details>

## Changes Made

1. **Added `isUnanimousVote()` helper** in `multi-sampler.ts`:
   - Simple function to check if all votes are the same
   - Handles edge cases (empty array, single vote)

2. **Added `is_unanimous` field** to `MultiSampleResult` interface:
   - Boolean indicating if all samples agreed on trigger_accuracy
   - Set in both `evaluateWithMultiSampling` and `evaluateSingleSample`

3. **Extended `sampleData` type** with `hasConsensus`:
   - Propagated from `is_unanimous` through `evaluateScenario`
   - Used by `calculateMultiSampleStats`

4. **Updated `calculateMultiSampleStats`**:
   - Now calculates `consensus_rate` from actual `hasConsensus` values
   - Formula: `consensusCount / sampleData.length`

5. **Added comprehensive tests**:
   - Unit tests for `isUnanimousVote` helper
   - Tests for `is_unanimous` in multi-sampling results
   - Tests for `calculateMultiSampleStats` with hasConsensus
   - Integration tests for consensus propagation

## Alternatives Considered

1. **Modify `getMajorityVote` return type** - Rejected because it would be a breaking change to an existing function signature
2. **Track all individual votes** - Rejected as overkill for current requirements
3. **Inline unanimity check** - Rejected in favor of a testable helper function

## Reviewer Notes

**Areas that need special attention**:
- The `isUnanimousVote` helper function at lines 145-167 in multi-sampler.ts
- Integration between `evaluateScenario` and `sampleData` collection

**Known limitations or trade-offs**:
- Single samples are marked as `is_unanimous: true` (trivially true)
- Error fallbacks also use `is_unanimous: true` to maintain data consistency

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)