### PR TITLE
feat(security): validate custom sanitization regex patterns

### DIFF
--- a/src/stages/3-execution/index.ts
+++ b/src/stages/3-execution/index.ts
@@ -24,6 +24,7 @@ import { logger } from "../../utils/logging.js";
 import {
   createSanitizer,
   sanitizeTranscriptEvent,
+  validateRegexPattern,
 } from "../../utils/sanitizer.js";
 
 import {
@@ -306,9 +307,12 @@ function saveTranscripts(
 
   if (shouldSanitize) {
     const customPatterns = config.output.sanitization?.custom_patterns?.map(
-      (p) => ({
-        name: "custom",
-        pattern: new RegExp(p.pattern, "g"),
+      (p, index) => ({
+        name: `custom_${String(index)}`,
+        pattern: validateRegexPattern(
+          p.pattern,
+          `custom_patterns[${String(index)}]`,
+        ),
         replacement: p.replacement,
       }),
     );

--- a/src/utils/sanitizer.ts
+++ b/src/utils/sanitizer.ts
@@ -134,6 +134,10 @@ export const DEFAULT_REDACTION_PATTERNS: RedactionPattern[] = [
  * Validates that the pattern is syntactically correct and compiles it
  * with the global flag. Throws a descriptive error if the pattern is invalid.
  *
+ * Note: Does not currently detect ReDoS-vulnerable patterns (catastrophic
+ * backtracking). Consider adding safe-regex library if patterns become
+ * user-controlled or if ReDoS becomes a concern.
+ *
  * @param pattern - The regex pattern string to validate and compile
  * @param name - Human-readable name for the pattern (used in error messages)
  * @returns Compiled RegExp with 'g' flag

--- a/src/utils/sanitizer.ts
+++ b/src/utils/sanitizer.ts
@@ -7,6 +7,8 @@
  * @module
  */
 
+import { ConfigLoadError } from "../config/loader.js";
+
 import type {
   AssistantEvent,
   ToolResultEvent,
@@ -125,6 +127,38 @@ export const DEFAULT_REDACTION_PATTERNS: RedactionPattern[] = [
     replacement: "[REDACTED_CARD]",
   },
 ];
+
+/**
+ * Validate and compile a regex pattern string.
+ *
+ * Validates that the pattern is syntactically correct and compiles it
+ * with the global flag. Throws a descriptive error if the pattern is invalid.
+ *
+ * @param pattern - The regex pattern string to validate and compile
+ * @param name - Human-readable name for the pattern (used in error messages)
+ * @returns Compiled RegExp with 'g' flag
+ * @throws ConfigLoadError if the pattern has invalid regex syntax
+ *
+ * @example
+ * ```typescript
+ * // Valid pattern
+ * const regex = validateRegexPattern("INTERNAL-\\w+", "internal_id");
+ * console.log(regex.test("INTERNAL-abc123")); // true
+ *
+ * // Invalid pattern throws
+ * validateRegexPattern("[invalid(", "broken"); // throws ConfigLoadError
+ * ```
+ */
+export function validateRegexPattern(pattern: string, name: string): RegExp {
+  try {
+    return new RegExp(pattern, "g");
+  } catch (error) {
+    throw new ConfigLoadError(
+      `Invalid regex pattern "${name}": ${error instanceof Error ? error.message : String(error)}`,
+      error instanceof Error ? error : undefined,
+    );
+  }
+}
 
 /**
  * Create a sanitizer function with the specified options.

--- a/tests/unit/utils/sanitizer.test.ts
+++ b/tests/unit/utils/sanitizer.test.ts
@@ -377,3 +377,69 @@ describe("sanitizeTranscriptEvent", () => {
     expect(result).not.toBe(unknownEvent); // Verify it's a new object
   });
 });
+
+describe("validateRegexPattern", () => {
+  // Import will be added once function is implemented
+  // This is expected to fail initially (TDD)
+
+  it("returns compiled RegExp for valid pattern", async () => {
+    const { validateRegexPattern } =
+      await import("../../../src/utils/sanitizer.js");
+    const result = validateRegexPattern("test-\\d+", "test_pattern");
+    expect(result).toBeInstanceOf(RegExp);
+    expect(result.flags).toBe("g");
+    expect(result.test("test-123")).toBe(true);
+  });
+
+  it("returns compiled RegExp for complex but valid pattern", async () => {
+    const { validateRegexPattern } =
+      await import("../../../src/utils/sanitizer.js");
+    const result = validateRegexPattern(
+      "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+      "email_pattern",
+    );
+    expect(result).toBeInstanceOf(RegExp);
+  });
+
+  it("throws ConfigLoadError for invalid regex syntax", async () => {
+    const { validateRegexPattern } =
+      await import("../../../src/utils/sanitizer.js");
+    expect(() => validateRegexPattern("[invalid(", "broken_pattern")).toThrow();
+  });
+
+  it("includes pattern name in error message", async () => {
+    const { validateRegexPattern } =
+      await import("../../../src/utils/sanitizer.js");
+    expect(() =>
+      validateRegexPattern("[invalid(", "my_custom_pattern"),
+    ).toThrow(/my_custom_pattern/);
+  });
+
+  it("includes original error message in thrown error", async () => {
+    const { validateRegexPattern } =
+      await import("../../../src/utils/sanitizer.js");
+    try {
+      validateRegexPattern("[invalid(", "test");
+      expect.fail("Should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(Error);
+      expect((error as Error).message).toMatch(/Invalid/i);
+    }
+  });
+
+  it("handles empty pattern string", async () => {
+    const { validateRegexPattern } =
+      await import("../../../src/utils/sanitizer.js");
+    // Empty pattern is technically valid regex (matches empty string)
+    const result = validateRegexPattern("", "empty_pattern");
+    expect(result).toBeInstanceOf(RegExp);
+  });
+
+  it("handles pattern with special regex characters", async () => {
+    const { validateRegexPattern } =
+      await import("../../../src/utils/sanitizer.js");
+    const result = validateRegexPattern("\\$\\d+\\.\\d{2}", "currency");
+    expect(result).toBeInstanceOf(RegExp);
+    expect(result.test("$19.99")).toBe(true);
+  });
+});

--- a/tests/unit/utils/sanitizer.test.ts
+++ b/tests/unit/utils/sanitizer.test.ts
@@ -404,7 +404,9 @@ describe("validateRegexPattern", () => {
   it("throws ConfigLoadError for invalid regex syntax", async () => {
     const { validateRegexPattern } =
       await import("../../../src/utils/sanitizer.js");
-    expect(() => validateRegexPattern("[invalid(", "broken_pattern")).toThrow();
+    expect(() => validateRegexPattern("[invalid(", "broken_pattern")).toThrow(
+      /Invalid regex pattern/,
+    );
   });
 
   it("includes pattern name in error message", async () => {


### PR DESCRIPTION
## Description

Add `validateRegexPattern` function to validate and compile regex patterns before use. This prevents crashes from malformed regex patterns in `config.yaml` custom_patterns and provides clear error messages for debugging.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Performance optimization (improves efficiency without changing behavior)
- [ ] Refactoring (code change that neither fixes a bug nor adds a feature)
- [ ] Test (adding or updating tests)
- [ ] Documentation update (improvements to README, CLAUDE.md, or inline docs)
- [ ] Configuration change (changes to config.yaml, eslint, tsconfig, etc.)

## Component(s) Affected

### Pipeline Stages

- [ ] Stage 1: Analysis (`src/stages/1-analysis/`)
- [ ] Stage 2: Generation (`src/stages/2-generation/`)
- [x] Stage 3: Execution (`src/stages/3-execution/`)
- [ ] Stage 4: Evaluation (`src/stages/4-evaluation/`)

### Core Infrastructure

- [ ] CLI & Pipeline Orchestration (`src/index.ts`)
- [ ] Configuration (`src/config/`)
- [ ] State Management (`src/state/`)
- [ ] Types (`src/types/`)
- [x] Utilities (`src/utils/`)

### Other

- [x] Tests (`tests/`)
- [ ] Documentation (`CLAUDE.md`, `README.md`)
- [ ] Configuration files (`config.yaml`, `eslint.config.js`, `tsconfig.json`, etc.)
- [ ] GitHub templates/workflows (`.github/`)
- [ ] Other (please specify):

## Motivation and Context

Custom sanitization regex patterns from `config.yaml` were previously compiled without validation, which could cause:
- Crashes if invalid regex syntax was provided
- Potential ReDoS (Regular Expression Denial of Service) if patterns have catastrophic backtracking

This is a defense-in-depth security improvement. While patterns come from config files (not runtime user input), validation provides better error messages and crash protection.

Fixes #40

## How Has This Been Tested?

**Test Configuration**:

- Node.js version: v25.2.1
- OS: macOS Darwin 25.2.0

**Test Steps**:

1. `npm run typecheck` - TypeScript strict mode passes
2. `npm run lint` - ESLint passes
3. `npx prettier --check "src/**/*.ts" "tests/**/*.ts"` - Prettier passes
4. `markdownlint "*.md"` - Markdown linting passes
5. `npm test` - All 943 tests pass

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### TypeScript / Code Quality

- [x] All functions have explicit return types
- [x] Strict TypeScript checks pass (`npm run typecheck`)
- [x] ESM import/export patterns used correctly
- [x] Unused parameters prefixed with `_`
- [x] No `any` types without justification

### Documentation

- [ ] I have updated CLAUDE.md if behavior or commands changed
- [x] I have updated inline JSDoc comments where applicable
- [x] I have verified all links work correctly

### Linting

- [x] I have run `npm run lint` and fixed all issues
- [x] I have run `npx prettier --check "src/**/*.ts" "*.json" "*.md"`
- [x] I have run `markdownlint "*.md"` on Markdown files
- [ ] I have run `uvx yamllint -c .yamllint.yml` on YAML files (if modified)
- [ ] I have run `actionlint` on workflow files (if modified)

### Testing

- [x] I have run `npm test` and all tests pass
- [x] I have added tests for new functionality
- [x] Test coverage meets thresholds (78% lines, 75% functions, 65% branches)
- [ ] I have tested with a sample plugin (if applicable)

## Stage-Specific Checks

<details>
<summary><strong>Stage 3: Execution</strong> (click to expand)</summary>

- [ ] Claude Agent SDK integration works correctly
- [ ] Tool capture via PreToolUse hooks functions properly
- [ ] Timeout handling works as expected
- [ ] Session isolation prevents cross-contamination
- [ ] Permission bypass works for automated execution

</details>

## Example Output (if applicable)

```typescript
// Valid pattern compiles successfully
const regex = validateRegexPattern("INTERNAL-\\w+", "internal_id");
// Returns: /INTERNAL-\w+/g

// Invalid pattern throws descriptive error
validateRegexPattern("[invalid(", "broken");
// Throws: ConfigLoadError: Invalid regex pattern "broken": Invalid regular expression...
```

## Additional Notes

This implementation follows "Option 1" from the issue - lightweight syntax validation without external dependencies. ReDoS detection was considered but deferred since:
- Patterns come from config files, not runtime user input
- Risk is low (likelihood) with medium impact
- A dependency-free solution fits the project better

## Reviewer Notes

**Areas that need special attention**:

- The `validateRegexPattern` function in `src/utils/sanitizer.ts`
- The updated pattern compilation in `src/stages/3-execution/index.ts`

**Known limitations or trade-offs**:

- Does not detect ReDoS-vulnerable patterns (catastrophic backtracking)
- Could be added later with `safe-regex` library if needed

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)