### PR TITLE
chore: prepare release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,38 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0] - 2026-01-02
+
 ### Added
 
 - Initial 4-stage evaluation pipeline (Analysis → Generation → Execution → Evaluation)
 - Support for skills, agents, and commands evaluation
 - Programmatic detection via tool capture parsing
-- LLM judge for quality assessment
+- LLM judge for quality assessment with multi-sampling
 - Resume capability with state checkpointing
-- Cost estimation before execution
+- Cost estimation before execution (dry-run mode)
 - Multiple output formats (JSON, YAML, JUnit XML, TAP)
 - Semantic variation testing for trigger robustness
-
-<!--
-## [0.1.0] - YYYY-MM-DD
-
-### Added
-- New features
+- Rate limiter for API call protection (#32)
+- Symlink resolution for plugin path validation (#33)
+- PII filtering for verbose transcript logging (#34)
+- Custom sanitization regex pattern validation (#46)
+- Comprehensive test suite with 943 tests and 93%+ coverage
 
 ### Changed
-- Changes to existing functionality
 
-### Deprecated
-- Features that will be removed in future versions
-
-### Removed
-- Features that were removed
+- Tuning configuration extracted from hardcoded values (#26)
+- Renamed seed.yaml to config.yaml for clarity (#25)
 
 ### Fixed
-- Bug fixes
 
-### Security
-- Security-related changes
+- Correct Anthropic structured output API usage in LLM judge (#9)
+- Variance propagation from runJudgment to metrics (#30)
+- Centralized logger and pricing utilities (#43)
 
 [Unreleased]: https://github.com/sjnims/cc-plugin-eval/compare/v0.1.0...HEAD
 [0.1.0]: https://github.com/sjnims/cc-plugin-eval/releases/tag/v0.1.0
--->


### PR DESCRIPTION
## Release v0.1.0

First release of cc-plugin-eval - a 4-stage evaluation framework for testing Claude Code plugin component triggering.

### Summary
- Initial 4-stage evaluation pipeline (Analysis → Generation → Execution → Evaluation)
- Support for skills, agents, and commands evaluation
- Programmatic detection via tool capture parsing
- LLM judge for quality assessment with multi-sampling
- Resume capability with state checkpointing
- Cost estimation before execution (dry-run mode)
- Multiple output formats (JSON, YAML, JUnit XML, TAP)
- Comprehensive test suite with 943 tests and 93%+ coverage

### Checklist
- [x] Version already at 0.1.0 in package.json
- [x] CHANGELOG.md updated with release notes
- [x] All CI checks pass
- [x] All linters pass (TypeScript, ESLint, Prettier, markdownlint, yamllint, actionlint)
- [x] All tests pass (943 tests, 93%+ coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)