### PR TITLE
feat: add Stop hook for clean vs forced termination detection

### DIFF
--- a/src/stages/3-execution/sdk-client.ts
+++ b/src/stages/3-execution/sdk-client.ts
@@ -17,6 +17,7 @@ import {
   type PostToolUseFailureHookInput as SDKPostToolUseFailureHookInput,
   type SubagentStartHookInput as SDKSubagentStartHookInput,
   type SubagentStopHookInput as SDKSubagentStopHookInput,
+  type StopHookInput as SDKStopHookInput,
   type PermissionMode,
   type SettingSource,
   type SDKUserMessage as SDKUserMessageType,
@@ -118,6 +119,13 @@ export type SubagentStartHookInput = SDKSubagentStartHookInput;
 export type SubagentStopHookInput = SDKSubagentStopHookInput;
 
 /**
+ * Stop hook input from SDK.
+ * Fired when the agent finishes execution (clean completion).
+ * Re-exported for use in other modules.
+ */
+export type StopHookInput = SDKStopHookInput;
+
+/**
  * Hook callback signature matching Agent SDK.
  * Re-exported for use in other modules.
  */
@@ -152,6 +160,12 @@ export type SubagentStartHookConfig = HookCallbackMatcher;
  * Uses SDK's HookCallbackMatcher type.
  */
 export type SubagentStopHookConfig = HookCallbackMatcher;
+
+/**
+ * Hook configuration for Stop.
+ * Uses SDK's HookCallbackMatcher type.
+ */
+export type StopHookConfig = HookCallbackMatcher;
 
 /**
  * Plugin reference for SDK options.

--- a/src/stages/3-execution/tool-capture-hooks.ts
+++ b/src/stages/3-execution/tool-capture-hooks.ts
@@ -268,16 +268,6 @@ export function createSubagentStopHook(
 }
 
 /**
- * Creates a Stop hook callback that updates captures when a stop event occurs.
- *
- * The hook:
- * 1. Looks up the capture from PreToolUse via toolUseId in the map
- * 2. Updates the capture with stop timestamp and reason
- *
- * @param captureMap - Map for correlating PreToolUse/Stop hooks by toolUseId
- * @returns Hook callback function for use with the Agent SDK
- */
-/**
  * Callback invoked when the Stop hook fires (agent completed cleanly).
  */
 export type OnStopCapture = () => void;
@@ -289,8 +279,8 @@ export type OnStopCapture = () => void;
  * 1. Validates the input is a Stop event
  * 2. Calls the onStop callback to signal clean termination
  *
- * This is a stateless hook — it simply sets a flag, no per-scenario
- * state is needed.
+ * This is a stateful hook — the onStop callback is a per-scenario closure
+ * for signaling clean termination.
  *
  * @param onStop - Callback invoked when the agent stops cleanly
  * @returns Hook callback function for use with the Agent SDK

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -72,6 +72,7 @@ export type {
   TranscriptEvent,
   Transcript,
   ExecutionResult,
+  TerminationType,
 } from "./transcript.js";
 
 // Evaluation types

--- a/src/types/transcript.ts
+++ b/src/types/transcript.ts
@@ -184,6 +184,14 @@ export interface Transcript {
 }
 
 /**
+ * Type of scenario termination.
+ * - "clean": Agent finished normally (Stop hook received)
+ * - "timeout": Forced termination via AbortController
+ * - "error": Unexpected failure during execution
+ */
+export type TerminationType = "clean" | "timeout" | "error";
+
+/**
  * Result of executing a scenario.
  */
 export interface ExecutionResult {
@@ -207,4 +215,6 @@ export interface ExecutionResult {
   cache_read_tokens?: number;
   /** Total cache creation tokens across all models */
   cache_creation_tokens?: number;
+  /** How the scenario terminated: clean completion, timeout, or error */
+  termination_type?: TerminationType;
 }


### PR DESCRIPTION
## Description

Register the SDK v0.2.25 `Stop` hook to capture explicit completion signals from scenarios. This enables reliable distinction between clean completion, timeout/abort, and error termination via a new `termination_type` field on `ExecutionResult`.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component(s) Affected

### Pipeline Stages

- [x] Stage 3: Execution (`src/stages/3-execution/`)

### Core Infrastructure

- [x] Types (`src/types/`)

### Other

- [x] Tests (`tests/`)

## Motivation and Context

Currently there is no explicit signal distinguishing clean scenario completion from timeout/abort or error termination. Timeout detection relies on `AbortError` checks, but there's no positive signal for clean completion. The Stop hook provides an authoritative, SDK-provided signal.

Fixes #346

## How Has This Been Tested?

**Test Configuration**:

- Node.js version: 20+
- OS: macOS (Darwin 25.2.0)

**Test Steps**:

1. `npm run build` — compiles without errors
2. `npm run lint` — no lint errors
3. `npm run typecheck` — strict TypeScript checks pass
4. `npm run format:check` — all files formatted
5. `npm run knip` — no unused exports
6. `npm test` — all 1592 tests pass (62 test files)

## Checklist

### General

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors

### TypeScript / Code Quality

- [x] All functions have explicit return types
- [x] Strict TypeScript checks pass (`npm run typecheck`)
- [x] ESM import/export patterns used correctly
- [x] Unused parameters prefixed with `_`
- [x] No `any` types without justification

### Documentation

- [x] I have updated inline JSDoc comments where applicable

### Linting

- [x] I have run `npm run lint` and fixed all issues
- [x] I have run `npm run format:check`

### Testing

- [x] I have run `npm test` and all tests pass
- [x] I have added tests for new functionality
- [x] Test coverage meets thresholds (78% lines, 75% functions, 65% branches)

## Stage-Specific Checks

<details>
<summary><strong>Stage 3: Execution</strong> (click to expand)</summary>

- [x] Claude Agent SDK integration works correctly
- [x] Tool capture via PreToolUse hooks functions properly
- [x] Timeout handling works as expected
- [x] Session isolation prevents cross-contamination
- [x] Permission bypass works for automated execution

</details>

## API & SDK Changes

<details>
<summary><strong>SDK Integration</strong> (click to expand)</summary>

- [x] Claude Agent SDK integration maintains compatibility
- [x] Token/cost estimation remains accurate

</details>

## Changes

| File | Change |
|------|--------|
| `src/stages/3-execution/sdk-client.ts` | Import `StopHookInput` from SDK, add `StopHookConfig` type alias |
| `src/stages/3-execution/tool-capture-hooks.ts` | Add `isStopInput()` type guard, `OnStopCapture` type, `createStopHook()` factory |
| `src/stages/3-execution/hooks-factory.ts` | Add `Stop` to `SDKHooksConfig`, `stopHook` to `StatefulHooks`, wire into all factory functions |
| `src/types/transcript.ts` | Add `TerminationType` type and optional `termination_type` field on `ExecutionResult` |
| `src/stages/3-execution/agent-executor.ts` | Add `stopReceived` to `ExecutionContext`, `deriveTerminationType()` helper, wire through both execution paths |
| `src/stages/3-execution/session-batching.ts` | Mirror agent-executor changes for batched execution path |
| Tests (3 files) | Unit tests for `createStopHook`, Stop hook in factory tests, `deriveTerminationType` tests |

## Reviewer Notes

**Areas that need special attention**:

- `deriveTerminationType` logic: when Stop hook fires, it's always "clean" even if there are errors (the Stop signal is authoritative). When no Stop hook and no errors, defaults to "clean" for backward compatibility.
- The Stop hook is classified as **stateful** (not stateless) because it needs a per-scenario `onStop` callback closure, unlike the map-based stateless hooks.

**Known limitations or trade-offs**:

- The Stop hook may not fire in all SDK configurations or if the agent is aborted before completion. The `deriveTerminationType` function gracefully handles this by defaulting to "clean" when no errors and no Stop hook are present.
- `termination_type` is optional on `ExecutionResult` for backward compatibility with existing serialized state files. No `migrateState()` update needed.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)